### PR TITLE
[nrf toup] [Crypto] Stop compiling legacy SPAKE2P if PSA is available

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -380,6 +380,7 @@ config MBEDTLS_ECP_C
     default y
 
 config MBEDTLS_ECP_DP_SECP256R1_ENABLED
+    bool
     default y
 
 endif # !CHIP_CRYPTO_PSA
@@ -420,6 +421,10 @@ config MBEDTLS_SSL_COOKIE_C
     default n
 
 config MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
+    default y
+
+config MBEDTLS_LEGACY_CRYPTO_C
+    bool
     default y
 
 # ==============================================================================

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -761,6 +761,9 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     return CHIP_NO_ERROR;
 }
 
+// We should compile this SPAKE2P implementation only if the PSA implementation is not in use.
+#if !CHIP_CRYPTO_PSA_SPAKE2P
+
 typedef struct Spake2p_Context
 {
     mbedtls_ecp_group curve;
@@ -1065,6 +1068,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 
     return CHIP_NO_ERROR;
 }
+
+#endif // !CHIP_CRYPTO_PSA_SPAKE2P
 
 } // namespace Crypto
 } // namespace chip


### PR DESCRIPTION
If the CHIP_CRYPTO_PSA_SPAKE2P is enabled the build system should not compile Legacy Spake2p implementation, because the PSA one is available in the PSASpake2p.cpp file.

